### PR TITLE
Improve performance of image comparison logic for tests

### DIFF
--- a/UglyToad.PdfPig.Rendering.Skia.Tests/PdfToImageHelper.cs
+++ b/UglyToad.PdfPig.Rendering.Skia.Tests/PdfToImageHelper.cs
@@ -45,6 +45,18 @@ namespace UglyToad.PdfPig.Rendering.Skia.Tests
 
         private const byte _threshold = 2;
 
+        /// <summary>
+        /// Returns the byte offsets of the R, G, B channels within a pixel for the given color type.
+        /// Byte order follows the naming convention: e.g. Bgra8888 → B=0, G=1, R=2, A=3.
+        /// </summary>
+        private static (int r, int g, int b) GetRgbChannelOffsets(SKColorType colorType) => colorType switch
+        {
+            SKColorType.Bgra8888 => (2, 1, 0),
+            SKColorType.Rgba8888 => (0, 1, 2),
+            SKColorType.Rgb888x  => (0, 1, 2),
+            _ => throw new NotSupportedException($"Color type {colorType} is not supported for pixel diffing.")
+        };
+
         private static SKBitmap? diffImages(SKBitmap bim1, SKBitmap bim2)
         {
             int minWidth = Math.Min(bim1.Width, bim2.Width);
@@ -52,38 +64,70 @@ namespace UglyToad.PdfPig.Rendering.Skia.Tests
             int maxWidth = Math.Max(bim1.Width, bim2.Width);
             int maxHeight = Math.Max(bim1.Height, bim2.Height);
 
+            // bim3 is always Rgb888x: memory layout is [R=0, G=1, B=2, X=3].
+            // createEmptyDiffImage pre-fills the overlap area with white, so equal
+            // pixels don't need to be written explicitly.
             SKBitmap? bim3 = null;
+            Span<byte> span3 = default;
+            int rowBytes3 = 0;
+            int bpp3 = 0;
+
             if (minWidth != maxWidth || minHeight != maxHeight)
             {
                 bim3 = createEmptyDiffImage(minWidth, minHeight, maxWidth, maxHeight);
+                span3 = bim3.GetPixelSpan();
+                rowBytes3 = bim3.RowBytes;
+                bpp3 = bim3.BytesPerPixel;
             }
 
-            for (int x = 0; x < minWidth; ++x)
+            Span<byte> span1 = bim1.GetPixelSpan();
+            Span<byte> span2 = bim2.GetPixelSpan();
+
+            int bpp1 = bim1.BytesPerPixel;
+            int bpp2 = bim2.BytesPerPixel;
+            int rowBytes1 = bim1.RowBytes;
+            int rowBytes2 = bim2.RowBytes;
+
+            (int rOff1, int gOff1, int bOff1) = GetRgbChannelOffsets(bim1.ColorType);
+            (int rOff2, int gOff2, int bOff2) = GetRgbChannelOffsets(bim2.ColorType);
+
+            var sameColorTypes = bim1.ColorType == bim2.ColorType;
+
+            for (int y = 0; y < minHeight; ++y)
             {
-                for (int y = 0; y < minHeight; ++y)
+                for (int x = 0; x < minWidth; ++x)
                 {
-                    SKColor rgb1 = bim1.GetPixel(x, y);
-                    SKColor rgb2 = bim2.GetPixel(x, y);
-                    if (rgb1 != rgb2)
+                    int idx1 = y * rowBytes1 + x * bpp1;
+                    int idx2 = y * rowBytes2 + x * bpp2;
+
+                    // Quick equality short-circuit when both bitmaps share the same color type
+                    if (sameColorTypes && span1.Slice(idx1, bpp1).SequenceEqual(span2.Slice(idx2, bpp1)))
                     {
-                        byte rDiff = (byte)Math.Abs(rgb1.Red - rgb2.Red);
-                        byte gDiff = (byte)Math.Abs(rgb1.Green - rgb2.Green);
-                        byte bDiff = (byte)Math.Abs(rgb1.Blue - rgb2.Blue);
-
-                        if (rDiff <= _threshold && gDiff <= _threshold && bDiff <= _threshold)
-                        {
-                            // don't bother about small differences
-                            continue;
-                        }
-
-                        bim3 ??= createEmptyDiffImage(minWidth, minHeight, maxWidth, maxHeight);
-
-                        bim3.SetPixel(x, y, new SKColor(Math.Min((byte)125, rDiff), Math.Min((byte)125, gDiff), Math.Min((byte)125, bDiff)));
+                        continue;
                     }
-                    else
+
+                    byte rDiff = (byte)Math.Abs(span1[idx1 + rOff1] - span2[idx2 + rOff2]);
+                    byte gDiff = (byte)Math.Abs(span1[idx1 + gOff1] - span2[idx2 + gOff2]);
+                    byte bDiff = (byte)Math.Abs(span1[idx1 + bOff1] - span2[idx2 + bOff2]);
+
+                    if (rDiff <= _threshold && gDiff <= _threshold && bDiff <= _threshold)
                     {
-                        bim3?.SetPixel(x, y, SKColors.White);
+                        // don't bother about small differences
+                        continue;
                     }
+
+                    if (bim3 is null)
+                    {
+                        bim3 = createEmptyDiffImage(minWidth, minHeight, maxWidth, maxHeight);
+                        span3 = bim3.GetPixelSpan();
+                        rowBytes3 = bim3.RowBytes;
+                        bpp3 = bim3.BytesPerPixel;
+                    }
+
+                    int idx3 = y * rowBytes3 + x * bpp3;
+                    span3[idx3]     = Math.Min((byte)125, rDiff);
+                    span3[idx3 + 1] = Math.Min((byte)125, gDiff);
+                    span3[idx3 + 2] = Math.Min((byte)125, bDiff);
                 }
             }
 


### PR DESCRIPTION
Pixel comparison logic switched to Span comparisons intead of slower individual SKBitmap.GetPixel and SetPixel calls. Implemented a short-circuit optimization: when both images have the same bytes-per-pixel and their pixel data matches exactly, the code skips further diff calculations for that pixel.