### PR TITLE
Added possibility to set default font to prevent exception throw when uses SKTypeface.Default

### DIFF
--- a/UglyToad.PdfPig.Rendering.Skia/Helpers/SkiaFontCache.Font.cs
+++ b/UglyToad.PdfPig.Rendering.Skia/Helpers/SkiaFontCache.Font.cs
@@ -40,11 +40,21 @@ namespace UglyToad.PdfPig.Rendering.Skia.Helpers
         /// </summary>
         private const string NotoFont = "Noto";
 
-        private readonly Lazy<SkiaFontCacheItem> DefaultSkiaFontCacheItem = new(() => new SkiaFontCacheItem(SKTypeface.Default)); // Do not make static
+        private readonly Lazy<SkiaFontCacheItem> DefaultSkiaFontCacheItem; // Do not make static
 
         private readonly ConcurrentDictionary<IFont, ConcurrentDictionary<int, Lazy<SKPath?>>> _cache = new();
 
         private readonly ConcurrentDictionary<string, List<SkiaFontCacheItem>> _typefaces = new();
+
+        internal SkiaFontCache()
+        {
+            DefaultSkiaFontCacheItem = new(() => new SkiaFontCacheItem(SKTypeface.Default));
+        }
+
+        internal SkiaFontCache(SKTypeface defaultSKTypeface)
+        {
+            DefaultSkiaFontCacheItem = new(() => new SkiaFontCacheItem(defaultSKTypeface));
+        }
 
         public SkiaFontCacheItem GetTypefaceOrFallback(IFont font, string unicode)
         {

--- a/UglyToad.PdfPig.Rendering.Skia/SkiaPageFactory.cs
+++ b/UglyToad.PdfPig.Rendering.Skia/SkiaPageFactory.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using SkiaSharp;
 using UglyToad.PdfPig.Annotations;
@@ -35,6 +36,12 @@ namespace UglyToad.PdfPig.Rendering.Skia;
 /// </summary>
 public sealed class SkiaPageFactory : BasePageFactory<SKPicture>, IDisposable
 {
+    /// <summary>
+    /// Replace default font with specific from this file path
+    /// </summary>
+    public static string? ReplaceDefaultFontPath { get; set; } // TODO: use Skia options (not PdfPig related)?
+    private readonly SKTypeface? _defaultSKTypeface;
+
     private readonly SkiaFontCache _fontCache;
 
     private static readonly AsyncLocal<CancellationToken> _currentToken = new();
@@ -56,7 +63,17 @@ public sealed class SkiaPageFactory : BasePageFactory<SKPicture>, IDisposable
         ParsingOptions parsingOptions)
         : base(pdfScanner, resourceStore, filterProvider, pageContentParser, parsingOptions)
     {
-        _fontCache = new SkiaFontCache();
+        if (ReplaceDefaultFontPath != null)
+        {
+            if (!File.Exists(ReplaceDefaultFontPath))
+            {
+                throw new FileNotFoundException($"{nameof(ReplaceDefaultFontPath)} file does not exist: '{ReplaceDefaultFontPath}'.");
+            }
+
+            _defaultSKTypeface = SKTypeface.FromFile(ReplaceDefaultFontPath);
+        }
+
+        _fontCache = _defaultSKTypeface != null ? new SkiaFontCache(_defaultSKTypeface) : new SkiaFontCache();
     }
 
     /// <inheritdoc/>
@@ -87,5 +104,9 @@ public sealed class SkiaPageFactory : BasePageFactory<SKPicture>, IDisposable
     public void Dispose()
     {
         _fontCache.Dispose();
+        if (_defaultSKTypeface != null)
+        {
+            _defaultSKTypeface.Dispose();
+        }
     }
 }


### PR DESCRIPTION
added possibility to set default font to prevent exception throw when uses SKTypeface.Default

close [#145](https://github.com/BobLd/PdfPig.Rendering.Skia/issues/145) issue
